### PR TITLE
fix duplicate alert when the user login

### DIFF
--- a/hooks/useLogger.tsx
+++ b/hooks/useLogger.tsx
@@ -5,7 +5,6 @@ import { CREATE_ERROR } from '@/services/GraphQL/errors/mutations'
 
 const useLogger = () => {
   const [createError] = useMutation(CREATE_ERROR)
-  toast.dismiss()
 
   const error = (
     error: Error,
@@ -56,7 +55,7 @@ const useLogger = () => {
     else toast(message)
   }
 
-  return { log, warn, error }
+  return { log, warn, error, toast }
 }
 
 export default useLogger

--- a/views/Login/index.tsx
+++ b/views/Login/index.tsx
@@ -10,12 +10,12 @@ import LoginLayout from './Layout'
 
 const Login: NextPage = () => {
   const [checkUserSession, { loading }] = useLazyQuery(USER_SESSION)
-  const { log, warn, error } = useLogger()
+  const { log, warn, error, toast } = useLogger()
   const router = useRouter()
 
   const onSubmit = async (formData: LoginInput) => {
     const { called, error: queryError, data } = await checkUserSession({ variables: formData })
-
+    toast.dismiss()
     if (called) {
       if (queryError) {
         error(queryError, 'Login:onSubmit', 'Error al verificar sesión...', 'SERVER_CONNECTION')


### PR DESCRIPTION
### Description

I have changed the way alerts are displayed, now it does not depend on the effect, it depends on when the user presses "Login".

fixes #72 

#### Screenshots
[Test](https://user-images.githubusercontent.com/82967045/186291007-432cfc81-998c-4891-b15d-2a7bc02a0078.webm)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test it

If applicable, describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

1. Go to Login page
2. Enter a valid user name and password.
3. Press "Ingresar"

### Checklist:

- [x] Doesn't break the current code.
- [x] Passes linters and test, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The branch is updated with the last dev branch changes.
