### PR TITLE
fix: change message codigo to usuario required

### DIFF
--- a/views/Login/LoginForm.tsx
+++ b/views/Login/LoginForm.tsx
@@ -32,7 +32,7 @@ const LoginForm: FC<LoginFormProps> = ({ onSubmit, loading }) => {
           required: true,
         })}
       />
-      {errors.memberCode && <small className={styles.error}>El código es requerido</small>}
+      {errors.memberCode && <small className={styles.error}>El usuario es requerido</small>}
       <PasswordInput placeholder="Contraseña" {...register('password', { required: true })} />
       {errors.password && <small className={styles.error}>La contraseña es requerida</small>}
       <SubmitButton isLoading={loading} disabled={loading} text="Ingresar" />


### PR DESCRIPTION
### Description

I have changed the message displayed on the button when the user login

fixes #71 

#### Screenshot

![image](https://user-images.githubusercontent.com/82967045/186329905-de3a72a1-1ab7-40a8-92ac-9b68c5219bc9.png)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test it

If applicable, describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

1. Go to the login page.
2. enter your only password
3. click "Login".

### Checklist:

- [x] Doesn't break the current code.
- [x] Passes linters and test, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The branch is updated with the last dev branch changes.
