### PR TITLE
fix: added query to check if the provider have provider_info

### DIFF
--- a/services/GraphQL/users/queries.ts
+++ b/services/GraphQL/users/queries.ts
@@ -16,6 +16,7 @@ export const USER_SESSION = gql`
           { member_code: { _eq: $memberCode } }
           { password: { _eq: $password } }
         ]
+        _or: [{ type: { _in: ["ADMIN", "SUPER_ADMIN", "TEST_ADMIN"] } }, { provider_info: { id: { _is_null: false } } }]
       }
     ) {
       ...UserInfoFragment


### PR DESCRIPTION
### Description

With this change, users with the role "Providers" but that don't have "Provider_info" couldn't log in into the ADMIN PANEL, since this is causing problems and crashing the APP.

The ADMIN role still can log in into the ADMIN_PANEL without problems, since they don't need to have PROVIDER_INFO to work 

With this PR we avoid the ADMIN_PANEL crash

fixes #228 

#### Screenshots

![lastrecord](https://user-images.githubusercontent.com/66505715/190223699-704f4d00-13cd-442f-865b-9397605b0245.gif)

#### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test it

If applicable, describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

1. Go to the deployment link
2. Enter the next accounts:
ADMIN:
user: TEST0001
pass: TEST0001

PROVIDER:
user: 00ROLLUX
pass: ROLLUX

CORRUPT PROVIDER USER:
user: PROVIDER2
pass: PROVIDER2

The first two should log in without problems, and the last should see a notification about that user hadn't been found

### Checklist:

- [x] Doesn't break the current code.
- [x] Passes linters and test, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The branch is updated with the last dev branch changes.
