### PR TITLE
fix: limit character with truncate

### DIFF
--- a/components/BackHeader/BackHeader.module.scss
+++ b/components/BackHeader/BackHeader.module.scss
@@ -67,10 +67,10 @@
 }
 
 .title {
+  max-width: 250px;
   overflow: hidden;
   padding-right: 1.25rem;
   text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 250px;
 }

--- a/components/BackHeader/BackHeader.module.scss
+++ b/components/BackHeader/BackHeader.module.scss
@@ -65,3 +65,12 @@
   display: flex;
   flex-direction: row;
 }
+
+.title {
+  overflow: hidden;
+  padding-right: 1.25rem;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 250px;
+}

--- a/components/BackHeader/index.tsx
+++ b/components/BackHeader/index.tsx
@@ -28,7 +28,7 @@ const BackHeader: FC<BackHeaderProps> = ({ to, commercialName, parentImageUrl })
       {parentImageUrl ? (
         <img src={parentImageUrl} alt={commercialName} className={styles['back-header-image']} />
       ) : (
-        <div>{commercialName}</div>
+        <div className={styles.title}>{commercialName}</div>
       )}
     </nav>
   )

--- a/components/ListHeader/ListHeader.module.scss
+++ b/components/ListHeader/ListHeader.module.scss
@@ -1,6 +1,7 @@
 @import 'colors';
 
 .nav {
+  align-items: center;
   background-color: $white;
   display: flex;
   flex-direction: row;
@@ -51,7 +52,11 @@
   }
 
   h1 {
-    align-items: center;
-    display: flex;
+    max-width: 250px;
+    overflow: hidden;
+    padding-right: 1.25rem;
+    text-align: right;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
### Description

Limit the size of the trade name with css. Now when a name is too long it will have 3 dots to shorten it.

fix #223 

#### Screenshots

![chrome_lsmT9VvNqT](https://user-images.githubusercontent.com/71513679/190277721-90673ea5-f12a-4468-b46b-0e4d6f454eca.gif)


#### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test it

1. Login provide user
2. See the header
3. Go to profile
4. edit comercial name whit many letters or words
5. See the header

