### PR TITLE
Changed error message color in Create Providers view

### DIFF
--- a/views/Providers/Create/Form.tsx
+++ b/views/Providers/Create/Form.tsx
@@ -29,7 +29,7 @@ const CreateProviderForm: FC<MutableProviderUserFormProps> = ({ onSubmit, loadin
           name="commercialName"
           required
         >
-          {errors.commercialName && <span>El nombre es requerido.</span>}
+          {errors.commercialName && <span className={styles['error-message']}>El nombre es requerido.</span>}
         </CustomInput>
       </div>
       <div className={styles['input-container']}>
@@ -42,7 +42,7 @@ const CreateProviderForm: FC<MutableProviderUserFormProps> = ({ onSubmit, loadin
           required
           type="date"
         >
-          {errors.createdAt && <span>La fecha de inicio es requerida.</span>}
+          {errors.createdAt && <span className={styles['error-message']}>La fecha de inicio es requerida.</span>}
         </CustomInput>
       </div>
       <div className={styles['input-container']}>
@@ -54,7 +54,7 @@ const CreateProviderForm: FC<MutableProviderUserFormProps> = ({ onSubmit, loadin
           name="memberCode"
           required
         >
-          {errors.memberCode && <span>El nombre de usuario es requerido.</span>}
+          {errors.memberCode && <span className={styles['error-message']}>El nombre de usuario es requerido.</span>}
         </CustomInput>
       </div>
       <div className={styles['input-container']}>
@@ -67,7 +67,7 @@ const CreateProviderForm: FC<MutableProviderUserFormProps> = ({ onSubmit, loadin
           required
           type="email"
         >
-          {errors.salesEmail && <span>El correo es requerido.</span>}
+          {errors.salesEmail && <span className={styles['error-message']}>El correo es requerido.</span>}
         </CustomInput>
       </div>
       <div className={styles['input-container']}>
@@ -80,7 +80,7 @@ const CreateProviderForm: FC<MutableProviderUserFormProps> = ({ onSubmit, loadin
           required
           type="password"
         >
-          {errors.password && <span>La contraseña es requerida</span>}
+          {errors.password && <span className={styles['error-message']}>La contraseña es requerida</span>}
         </CustomInput>
       </div>
       <div className={btnStyles['buttons-container']}>

--- a/views/Providers/Create/ProviderCreateForm.module.scss
+++ b/views/Providers/Create/ProviderCreateForm.module.scss
@@ -1,4 +1,4 @@
-@import 'layout';
+@import 'layout', 'colors';
 
 .container {
   display: flex;
@@ -21,4 +21,8 @@
   flex-wrap: wrap;
   gap: 14px;
   margin-top: auto;
+}
+
+.error-message {
+  color: $red;
 }


### PR DESCRIPTION
### Description

I checked to fix the problem of issue #236 , but there was already fixed, the text errors just need to change the color to red

fixes #236 

#### Screenshots

![imagen](https://user-images.githubusercontent.com/66505715/190658737-06449bdb-3c1e-4699-a95d-6ea3283f2918.png)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test it

Log in with admin credentials -> select Providers -> select add new Provider -> fill the form, left some fields emptied, try to send the form

### Checklist:

- [x] Doesn't break the current code.
- [x] Passes linters and test, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The branch is updated with the last dev branch changes.
